### PR TITLE
added dialogue state so tutorial only plays at first attempt of level

### DIFF
--- a/main/Assets/Scenes/Level1.unity
+++ b/main/Assets/Scenes/Level1.unity
@@ -8821,7 +8821,7 @@ Tilemap:
       m_AnimatedSprites:
       - {fileID: 7567335897535996333, guid: 099f5b3b6e9dcec4ba6c9f78c3f80159, type: 3}
       - {fileID: 6118587610413286070, guid: 099f5b3b6e9dcec4ba6c9f78c3f80159, type: 3}
-      m_AnimationSpeed: 5.0000005
+      m_AnimationSpeed: 5
       m_AnimationTimeOffset: 0
       m_IsLooping: 1
   - first: {x: 0, y: 2, z: 0}
@@ -12576,6 +12576,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 913b5427f7a5af340a76e5895893527e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  dialogueState: {fileID: 11400000, guid: 9b6939b63abf299439a8a4bf3eed0f7f, type: 2}
 --- !u!114 &2020131520
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/main/Assets/ScriptableObjects/DialogueState.asset
+++ b/main/Assets/ScriptableObjects/DialogueState.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 061e489d5697b8c42ae198c25584fd28, type: 3}
+  m_Name: DialogueState
+  m_EditorClassIdentifier: 
+  SpokeOnLevel1: 1

--- a/main/Assets/ScriptableObjects/DialogueState.asset.meta
+++ b/main/Assets/ScriptableObjects/DialogueState.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b6939b63abf299439a8a4bf3eed0f7f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/main/Assets/ScriptableObjects/DialogueState.cs
+++ b/main/Assets/ScriptableObjects/DialogueState.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "Dialogue State", order = 52)]
+public class DialogueState : ScriptableObject
+{
+    public bool SpokeOnLevel1;
+
+    public void Reset()
+    {
+        SpokeOnLevel1 = false;
+    }
+}

--- a/main/Assets/ScriptableObjects/DialogueState.cs.meta
+++ b/main/Assets/ScriptableObjects/DialogueState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 061e489d5697b8c42ae198c25584fd28
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/main/Assets/Scripts/DialogueScripts/Level1/Level1Cinematic.cs
+++ b/main/Assets/Scripts/DialogueScripts/Level1/Level1Cinematic.cs
@@ -4,16 +4,23 @@ using UnityEngine;
 
 public class Level1Cinematic : MonoBehaviour
 {
+    public DialogueState dialogueState;
     private bool CaoNotEncounteredYet;
     // Start is called before the first frame update
     void Start()
     {
-        this.GetComponents<DialogueTrigger>()[0].TriggerDialogue(); //Intro Dialogue
+        if (!dialogueState.SpokeOnLevel1)
+        {
+            this.GetComponents<DialogueTrigger>()[0].TriggerDialogue(); //Intro Dialogue
+            dialogueState.SpokeOnLevel1 = true;
+        }
         CaoNotEncounteredYet = true;
     }
 
-    public void onCaOFound(){
-        if(CaoNotEncounteredYet){
+    public void onCaOFound()
+    {
+        if (CaoNotEncounteredYet)
+        {
             this.GetComponents<DialogueTrigger>()[1].TriggerDialogue();
         }
         CaoNotEncounteredYet = false;


### PR DESCRIPTION
- Added a Dialogue State scriptable object that stores the state of whether dialogues have been played. For other levels, create a bool accordingly. 
- A dialogue is only played if the dialogue has not been triggered before.
- Reset() method is currently unused.
- Remember to attach the Dialogue State scriptable object to the DialogueEvents as such
![image](https://user-images.githubusercontent.com/28921108/89692678-f03dc080-d93e-11ea-8b68-4e03e9a7e433.png)

There are some cases that have been chosen to be ignored.
- Case of when player restarts level before tutorial finishes playing
- Case of when player wants to view the dialogue again